### PR TITLE
docker: adjust github actions workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,11 +15,7 @@ jobs:
     name: Build and Push
     uses: codex-storage/github-actions/.github/workflows/docker-reusable.yml@master
     with:
-      docker_file: docker/Dockerfile
-      dockerhub_repo: codexstorage/test
+      docker_file: docker/crawler.Dockerfile
+      dockerhub_repo: codexstorage/codex-network-crawler
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
-      amd64_builder: ubuntu-24.04
-      build_args: |
-        VITE_CODEX_API_URL=${VITE_CODEX_API_URL}
-        VITE_GEO_IP_URL="Plain text"
     secrets: inherit


### PR DESCRIPTION
A quick PR to adjust Docker workflow
- Use a proper Docker file path
- Use a proper DockerHub repository name
- Do not need to use a custom `amd64_builder`
- Do not pass `build_args`