### PR TITLE
docker: use own nim-lang docker image

### DIFF
--- a/docker/crawler.Dockerfile
+++ b/docker/crawler.Dockerfile
@@ -1,12 +1,11 @@
 # Variables
-ARG BUILDER=nimlang/nim:2.0.14
+ARG BUILDER=codexstorage/nim-lang:2.0.14
 ARG IMAGE=ubuntu:24.04
 ARG BUILD_HOME=/src
 ARG MAKE_PARALLEL=${MAKE_PARALLEL:-4}
 ARG NIMFLAGS="${NIMFLAGS:-"-d:disableMarchNative"}"
 ARG USE_LIBBACKTRACE=${USE_LIBBACKTRACE:-1}
 ARG APP_HOME=/crawler
-
 
 # Build
 FROM ${BUILDER} AS builder
@@ -26,11 +25,11 @@ RUN nimble build
 FROM ${IMAGE}
 ARG BUILD_HOME
 ARG APP_HOME
-ARG NAT_IP_AUTO
 
 WORKDIR ${APP_HOME}
 COPY --from=builder ${BUILD_HOME}/build/* /usr/local/bin
 COPY --from=builder --chmod=0755 ${BUILD_HOME}/docker/docker-entrypoint.sh /
 RUN apt-get update && apt-get install -y libgomp1 curl jq && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["codexcrawler"]


### PR DESCRIPTION
PR fixes multi-arch Docker builds by switching to self-managed multi-arch nim-lang image
```
codexstorage/nim-lang:2.0.14
```
