### PR TITLE
feat: add devnet bootstrap nodes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   linting:

--- a/codexcrawler/config.nim
+++ b/codexcrawler/config.nim
@@ -81,9 +81,18 @@ proc getDefaultTestnetBootNodes(): seq[string] =
     "spr:CiUIAhIhA-pnA5sLGDVbqEXsRxDUjQEpiSAximHNbyqr2DwLmTq8EgIDARo8CicAJQgCEiED6mcDmwsYNVuoRexHENSNASmJIDGKYc1vKqvYPAuZOrwQyrekvAYaCwoJBIDHOw-RAnc4KkcwRQIhAJtKNeTykcE5bkKwe-vhSmqyBwc2AnexqFX1tAQGLQJ4AiBJOPseqvI3PyEM8l3hY3zvelZU9lT03O7MA_8cUfF4Uw",
   ]
 
+proc getDefaultDevnetBootNodes(): seq[string] =
+  @[
+    "spr:CiUIAhIhA-VlcoiRm02KyIzrcTP-ljFpzTljfBRRKTIvhMIwqBqWEgIDARpJCicAJQgCEiED5WVyiJGbTYrIjOtxM_6WMWnNOWN8FFEpMi-EwjCoGpYQs8n8wQYaCwoJBHTKubmRAnU6GgsKCQR0yrm5kQJ1OipHMEUCIQDwUNsfReB4ty7JFS5WVQ6n1fcko89qVAOfQEHixa03rgIgan2-uFNDT-r4s9TOkLe9YBkCbsRWYCHGGVJ25rLj0QE",
+    "spr:CiUIAhIhApIj9p6zJDRbw2NoCo-tj98Y760YbppRiEpGIE1yGaMzEgIDARpJCicAJQgCEiECkiP2nrMkNFvDY2gKj62P3xjvrRhumlGISkYgTXIZozMQvcz8wQYaCwoJBAWhF3WRAnVEGgsKCQQFoRd1kQJ1RCpGMEQCIFZB84O_nzPNuViqEGRL1vJTjHBJ-i5ZDgFL5XZxm4HAAiB8rbLHkUdFfWdiOmlencYVn0noSMRHzn4lJYoShuVzlw",
+    "spr:CiUIAhIhApqRgeWRPSXocTS9RFkQmwTZRG-Cdt7UR2N7POoz606ZEgIDARpJCicAJQgCEiECmpGB5ZE9JehxNL1EWRCbBNlEb4J23tRHY3s86jPrTpkQj8_8wQYaCwoJBAXfEfiRAnVOGgsKCQQF3xH4kQJ1TipGMEQCIGWJMsF57N1iIEQgTH7IrVOgEgv0J2P2v3jvQr5Cjy-RAiAy4aiZ8QtyDvCfl_K_w6SyZ9csFGkRNTpirq_M_QNgKw",
+  ]
+
 proc getBootNodeStrings(input: string): seq[string] =
   if input == "testnet_sprs":
     return getDefaultTestnetBootNodes()
+  elif input == "devnet_sprs":
+    return getDefaultDevnetBootNodes()
   return input.split(";")
 
 proc stringToSpr(uri: string): SignedPeerRecord =

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,9 +21,34 @@ ETHPROVIDER=${CRAWLER_ETHPROVIDER:-NULL}
 MARKETPLACEADDRESS=${CRAWLER_MARKETPLACEADDRESS:-NULL}
 REQUESTCHECKDELAY=${CRAWLER_REQUESTCHECKDELAY:-10}
 
+# Marketplace address from URL
+if [[ -n "${MARKETPLACE_ADDRESS_FROM_URL}" ]]; then
+  WAIT=${MARKETPLACE_ADDRESS_FROM_URL_WAIT:-300}
+  SECONDS=0
+  SLEEP=1
+  # Run and retry if fail
+  while (( SECONDS < WAIT )); do
+    MARKETPLACE_ADDRESS=($(curl -s -f -m 5 "${MARKETPLACE_ADDRESS_FROM_URL}"))
+    # Check if exit code is 0 and returned value is not empty
+    if [[ $? -eq 0 && -n "${MARKETPLACE_ADDRESS}" ]]; then
+      export MARKETPLACEADDRESS="${MARKETPLACE_ADDRESS}"
+      break
+    else
+      # Sleep and check again
+      echo "Can't get Marketplace address from ${MARKETPLACE_ADDRESS_FROM_URL} - Retry in $SLEEP seconds / $((WAIT - SECONDS))"
+      sleep $SLEEP
+    fi
+  done
+fi
+
 # Update CLI arguments
 set -- "$@" --logLevel="${LOGLEVEL}" --publicIp="${PUBLICIP}" --metricsAddress="${METRICSADDRESS}" --metricsPort="${METRICSPORT}" --dataDir="${DATADIR}" --discoveryPort="${DISCPORT}" --bootNodes="${BOOTNODES}" --dhtEnable="${DHTENABLE}" --stepDelay="${STEPDELAY}" --revisitDelay="${REVISITDELAY}" --expiryDelay="${EXPIRYDELAY}" --checkDelay="${CHECKDELAY}" --marketplaceEnable="${MARKETPLACEENABLE}" --ethProvider="${ETHPROVIDER}" --marketplaceAddress="${MARKETPLACEADDRESS}" --requestCheckDelay="${REQUESTCHECKDELAY}"
 
+# Show
+echo -e "\nRun parameters:"
+vars=$(env | grep "CRAWLER_" | grep -v -e "[0-9]*_SERVICE_" -e "[0-9]*_NODEPORT_")
+echo -e "${vars//CRAWLER_/   - CRAWLER_}"
+echo -e "   - $@\n"
+
 # Run
-echo "Run Codex Crawler"
 exec "$@"


### PR DESCRIPTION
PR add Codex Devnet bootsrap nodes and also add a way to run CI workflow manually.

Example
```shell
docker run --rm \
  -e MARKETPLACE_ADDRESS_FROM_URL="https://marketplace.codex.storage/codex-devnet/latest" \
  -e CRAWLER_BOOTNODES="devnet_sprs" \
  codexstorage/codex-network-crawler:sha-a33e2ac
```

Part of https://github.com/codex-storage/infra-codex/issues/337.